### PR TITLE
Fix integration and save bug

### DIFF
--- a/chatgpt-workspace-enhancer/background/background.js
+++ b/chatgpt-workspace-enhancer/background/background.js
@@ -34,6 +34,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       });
       sendResponse({ success: true });
       return false;
+
+    case 'resetSettings':
+      initializeDefaultSettings()
+        .then(() => sendResponse({ success: true }))
+        .catch((err) => sendResponse({ error: err.message }));
+      return true;
     
     default:
       sendResponse({ error: 'Unknown action' });

--- a/chatgpt-workspace-enhancer/content/content.js
+++ b/chatgpt-workspace-enhancer/content/content.js
@@ -86,20 +86,7 @@
    * Initialize IndexedDB storage
    */
   async function initializeStorage() {
-    // This will be implemented in storage.js
-    // For now, we'll just log a placeholder
-    console.log('Storage initialization placeholder');
-    
-    // Mock data for development
-    state.folders = [
-      { folderId: 'folder1', name: 'Work', color: '#ff5733', order: 0 },
-      { folderId: 'folder2', name: 'Personal', color: '#33ff57', order: 1 }
-    ];
-    
-    state.tags = [
-      { tagId: 'tag1', name: 'Important', color: '#ff3333' },
-      { tagId: 'tag2', name: 'Research', color: '#3333ff' }
-    ];
+    await storageManager.initialize();
   }
 
   /**
@@ -161,26 +148,19 @@
    * Initialize UI components
    */
   function initializeUI() {
-    // This will initialize all UI components
-    // Each component will be in its own module in the ui/ directory
-    
-    // For now, we'll just add a simple indicator to show the extension is active
-    const indicator = document.createElement('div');
-    indicator.id = 'chatgpt-enhancer-indicator';
-    indicator.textContent = 'ChatGPT Workspace Enhancer Active';
-    indicator.style.position = 'fixed';
-    indicator.style.bottom = '10px';
-    indicator.style.right = '10px';
-    indicator.style.padding = '5px 10px';
-    indicator.style.backgroundColor = state.theme === 'dark' ? '#2a2a2a' : '#f0f0f0';
-    indicator.style.color = state.theme === 'dark' ? '#ffffff' : '#333333';
-    indicator.style.borderRadius = '4px';
-    indicator.style.fontSize = '12px';
-    indicator.style.zIndex = '9999';
-    document.body.appendChild(indicator);
-    
-    // Initialize sidebar enhancements (placeholder)
-    console.log('UI initialization placeholder');
+    window.enhancedSidebar = new EnhancedSidebar();
+    window.enhancedEditor = new EnhancedEditor();
+    window.commandPalette = new CommandPalette();
+    window.productivityManager = new ProductivityManager();
+    window.organizationManager = new OrganizationManager();
+    window.exportManager = new ExportManager();
+
+    window.enhancedSidebar.initialize();
+    window.enhancedEditor.initialize();
+    window.commandPalette.initialize();
+    window.productivityManager.initialize();
+    window.organizationManager.initialize();
+    window.exportManager.initialize();
   }
 
   /**
@@ -210,9 +190,9 @@
    * Open command palette
    */
   function openCommandPalette() {
-    console.log('Command palette placeholder');
-    // This will be implemented in command.js
-    alert('Command Palette (Coming Soon)');
+    if (window.commandPalette) {
+      window.commandPalette.toggle();
+    }
   }
 
   /**

--- a/chatgpt-workspace-enhancer/content/features/productivity.js
+++ b/chatgpt-workspace-enhancer/content/features/productivity.js
@@ -317,7 +317,7 @@ class ProductivityManager {
       const { settings } = await storageManager.getSettings();
       if (settings) {
         settings.scratchPad = this.scratchPadContent;
-        await storageManager.saveSettings({ settings }, null);
+        await storageManager.saveSettings(settings, null);
       }
     } catch (error) {
       console.error('Error saving scratch pad content:', error);

--- a/chatgpt-workspace-enhancer/manifest.json
+++ b/chatgpt-workspace-enhancer/manifest.json
@@ -21,7 +21,17 @@
   "content_scripts": [
     {
       "matches": ["https://chat.openai.com/*"],
-      "js": ["content/content.js"],
+      "js": [
+        "content/utils/dom.js",
+        "utils/storage.js",
+        "content/ui/sidebar.js",
+        "content/ui/editor.js",
+        "content/ui/command.js",
+        "content/features/organization.js",
+        "content/features/productivity.js",
+        "content/features/export.js",
+        "content/content.js"
+      ],
       "css": ["assets/css/common.css"]
     }
   ],

--- a/chatgpt-workspace-enhancer/utils/storage.js
+++ b/chatgpt-workspace-enhancer/utils/storage.js
@@ -215,3 +215,4 @@ class StorageManager {
 
 // Export as singleton
 const storageManager = new StorageManager();
+window.storageManager = storageManager;


### PR DESCRIPTION
## Summary
- export singleton `storageManager` to `window`
- include all helper scripts in `manifest.json`
- initialize sidebar, editor, command palette and other modules in `content.js`
- call command palette properly from message handler
- fix saving scratch pad content
- add resetSettings support in the background script

## Testing
- `for f in $(find chatgpt-workspace-enhancer -name '*.js'); do node --check "$f"; done`