### PR TITLE
Implement missing features and update domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ A lightweight, fully client-side browser extension designed to transform the sta
 
 ## Usage
 
-After installation, navigate to [chat.openai.com](https://chat.openai.com) and the extension will automatically activate.
+After installation, navigate to [chatgpt.com](https://chatgpt.com) and the extension will automatically activate.
 
 ### Keyboard Shortcuts
 

--- a/chatgpt-workspace-enhancer/background/background.js
+++ b/chatgpt-workspace-enhancer/background/background.js
@@ -34,6 +34,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       });
       sendResponse({ success: true });
       return false;
+
+    case 'resetSettings':
+      initializeDefaultSettings()
+        .then(() => sendResponse({ success: true }))
+        .catch((err) => sendResponse({ error: err.message }));
+      return true;
     
     default:
       sendResponse({ error: 'Unknown action' });

--- a/chatgpt-workspace-enhancer/content/content.js
+++ b/chatgpt-workspace-enhancer/content/content.js
@@ -86,20 +86,7 @@
    * Initialize IndexedDB storage
    */
   async function initializeStorage() {
-    // This will be implemented in storage.js
-    // For now, we'll just log a placeholder
-    console.log('Storage initialization placeholder');
-    
-    // Mock data for development
-    state.folders = [
-      { folderId: 'folder1', name: 'Work', color: '#ff5733', order: 0 },
-      { folderId: 'folder2', name: 'Personal', color: '#33ff57', order: 1 }
-    ];
-    
-    state.tags = [
-      { tagId: 'tag1', name: 'Important', color: '#ff3333' },
-      { tagId: 'tag2', name: 'Research', color: '#3333ff' }
-    ];
+    await storageManager.initialize();
   }
 
   /**
@@ -161,26 +148,19 @@
    * Initialize UI components
    */
   function initializeUI() {
-    // This will initialize all UI components
-    // Each component will be in its own module in the ui/ directory
-    
-    // For now, we'll just add a simple indicator to show the extension is active
-    const indicator = document.createElement('div');
-    indicator.id = 'chatgpt-enhancer-indicator';
-    indicator.textContent = 'ChatGPT Workspace Enhancer Active';
-    indicator.style.position = 'fixed';
-    indicator.style.bottom = '10px';
-    indicator.style.right = '10px';
-    indicator.style.padding = '5px 10px';
-    indicator.style.backgroundColor = state.theme === 'dark' ? '#2a2a2a' : '#f0f0f0';
-    indicator.style.color = state.theme === 'dark' ? '#ffffff' : '#333333';
-    indicator.style.borderRadius = '4px';
-    indicator.style.fontSize = '12px';
-    indicator.style.zIndex = '9999';
-    document.body.appendChild(indicator);
-    
-    // Initialize sidebar enhancements (placeholder)
-    console.log('UI initialization placeholder');
+    window.enhancedSidebar = new EnhancedSidebar();
+    window.enhancedEditor = new EnhancedEditor();
+    window.commandPalette = new CommandPalette();
+    window.productivityManager = new ProductivityManager();
+    window.organizationManager = new OrganizationManager();
+    window.exportManager = new ExportManager();
+
+    window.enhancedSidebar.initialize();
+    window.enhancedEditor.initialize();
+    window.commandPalette.initialize();
+    window.productivityManager.initialize();
+    window.organizationManager.initialize();
+    window.exportManager.initialize();
   }
 
   /**
@@ -210,9 +190,9 @@
    * Open command palette
    */
   function openCommandPalette() {
-    console.log('Command palette placeholder');
-    // This will be implemented in command.js
-    alert('Command Palette (Coming Soon)');
+    if (window.commandPalette) {
+      window.commandPalette.toggle();
+    }
   }
 
   /**

--- a/chatgpt-workspace-enhancer/content/features/export.js
+++ b/chatgpt-workspace-enhancer/content/features/export.js
@@ -247,8 +247,14 @@ class ExportManager {
    * @param {HTMLElement} messageElement - Message element
    */
   exportMessageAsPdf(messageElement) {
-    // This is a placeholder - in a real implementation, we would use a PDF generation library
-    alert('PDF export functionality coming soon');
+    const html = messageElement.outerHTML;
+    const win = window.open('', '_blank');
+    if (!win) return;
+    win.document.write(`<html><head><title>Chat Message</title></head><body>${html}</body></html>`);
+    win.document.close();
+    win.focus();
+    win.print();
+    win.close();
   }
 
   /**
@@ -294,8 +300,16 @@ class ExportManager {
    * Export entire chat as PDF
    */
   exportChatAsPdf() {
-    // This is a placeholder - in a real implementation, we would use a PDF generation library
-    alert('Full chat PDF export functionality coming soon');
+    const chatContainer = document.querySelector('main div.flex-1');
+    if (!chatContainer) return;
+    const html = chatContainer.innerHTML;
+    const win = window.open('', '_blank');
+    if (!win) return;
+    win.document.write(`<html><head><title>Chat Export</title></head><body>${html}</body></html>`);
+    win.document.close();
+    win.focus();
+    win.print();
+    win.close();
   }
 }
 

--- a/chatgpt-workspace-enhancer/content/features/productivity.js
+++ b/chatgpt-workspace-enhancer/content/features/productivity.js
@@ -317,7 +317,7 @@ class ProductivityManager {
       const { settings } = await storageManager.getSettings();
       if (settings) {
         settings.scratchPad = this.scratchPadContent;
-        await storageManager.saveSettings({ settings }, null);
+        await storageManager.saveSettings(settings, null);
       }
     } catch (error) {
       console.error('Error saving scratch pad content:', error);

--- a/chatgpt-workspace-enhancer/content/ui/command.js
+++ b/chatgpt-workspace-enhancer/content/ui/command.js
@@ -479,18 +479,17 @@ class CommandPalette {
         break;
         
       case 'toggle-theme':
-        // This is just a placeholder - actual implementation would depend on ChatGPT's theme toggle
-        alert('Theme toggle functionality coming soon');
+        document.documentElement.classList.toggle('dark');
         break;
-        
+
       case 'export-chat':
-        // This is just a placeholder - actual implementation would be in the export module
-        alert('Export functionality coming soon');
+        if (window.exportManager) {
+          window.exportManager.exportChatAsPdf();
+        }
         break;
-        
+
       case 'open-settings':
-        // This is just a placeholder - actual implementation would open the settings modal
-        alert('Settings functionality coming soon');
+        chrome.runtime.openOptionsPage();
         break;
         
       default:

--- a/chatgpt-workspace-enhancer/content/ui/sidebar.js
+++ b/chatgpt-workspace-enhancer/content/ui/sidebar.js
@@ -289,16 +289,37 @@ class EnhancedSidebar {
     
     pinnedSection.appendChild(sectionTitle);
     
-    // Add pinned chats (placeholder for now)
-    const placeholder = DOMUtils.createElement('div', {
-      style: {
-        padding: '8px',
-        fontSize: '14px',
-        color: 'rgba(0, 0, 0, 0.5)'
-      }
-    }, 'No pinned chats');
-    
-    pinnedSection.appendChild(placeholder);
+    if (this.pinnedChats.length > 0) {
+      const prefix = window.location.pathname.split('/c/')[0];
+      this.pinnedChats.forEach(chatId => {
+        const chatLink = DOMUtils.createElement('a', {
+          href: `${prefix}/c/${chatId}`,
+          class: 'chatgpt-enhancer-pinned-chat',
+          style: { textDecoration: 'none', color: 'inherit' }
+        });
+
+        const pinIcon = DOMUtils.createElement('span', {
+          class: 'chatgpt-enhancer-pin-icon'
+        }, '📌');
+
+        const title = DOMUtils.createElement('span', {}, chatId);
+
+        chatLink.appendChild(pinIcon);
+        chatLink.appendChild(title);
+
+        pinnedSection.appendChild(chatLink);
+      });
+    } else {
+      const placeholder = DOMUtils.createElement('div', {
+        style: {
+          padding: '8px',
+          fontSize: '14px',
+          color: 'rgba(0, 0, 0, 0.5)'
+        }
+      }, 'No pinned chats');
+
+      pinnedSection.appendChild(placeholder);
+    }
     
     // Insert after the folder section
     const folderSection = this.sidebarElement.querySelector('.chatgpt-enhancer-section');
@@ -332,8 +353,16 @@ class EnhancedSidebar {
    * @param {string} query - Search query
    */
   handleSearch(query) {
-    console.log('Search query:', query);
-    // This will be implemented with the search functionality
+    const chatLinks = this.sidebarElement.querySelectorAll('a[href*="/c/"]');
+
+    chatLinks.forEach(link => {
+      const text = link.textContent.toLowerCase();
+      if (text.includes(query.toLowerCase())) {
+        link.style.display = '';
+      } else {
+        link.style.display = 'none';
+      }
+    });
   }
 
   /**

--- a/chatgpt-workspace-enhancer/manifest.json
+++ b/chatgpt-workspace-enhancer/manifest.json
@@ -13,15 +13,25 @@
     "unlimitedStorage"
   ],
   "host_permissions": [
-    "https://chat.openai.com/*"
+    "https://chatgpt.com/*"
   ],
   "background": {
     "service_worker": "background/background.js"
   },
   "content_scripts": [
     {
-      "matches": ["https://chat.openai.com/*"],
-      "js": ["content/content.js"],
+      "matches": ["https://chatgpt.com/*"],
+      "js": [
+        "content/utils/dom.js",
+        "utils/storage.js",
+        "content/ui/sidebar.js",
+        "content/ui/editor.js",
+        "content/ui/command.js",
+        "content/features/organization.js",
+        "content/features/productivity.js",
+        "content/features/export.js",
+        "content/content.js"
+      ],
       "css": ["assets/css/common.css"]
     }
   ],
@@ -36,7 +46,7 @@
         "assets/icons/*",
         "lib/*"
       ],
-      "matches": ["https://chat.openai.com/*"]
+      "matches": ["https://chatgpt.com/*"]
     }
   ],
   "commands": {

--- a/chatgpt-workspace-enhancer/utils/storage.js
+++ b/chatgpt-workspace-enhancer/utils/storage.js
@@ -215,3 +215,4 @@ class StorageManager {
 
 // Export as singleton
 const storageManager = new StorageManager();
+window.storageManager = storageManager;


### PR DESCRIPTION
## Summary
- switch extension domain to `chatgpt.com`
- list pinned chats in the enhanced sidebar and add chat search filtering
- implement theme toggle, chat export and options page commands
- add simple PDF export for messages and whole chats

## Testing
- `for f in $(find chatgpt-workspace-enhancer -name '*.js'); do node --check "$f"; done`